### PR TITLE
Fix broken navigation and related article links

### DIFF
--- a/dist/GetStarted.html
+++ b/dist/GetStarted.html
@@ -252,7 +252,7 @@
                 <div class="related-grid">
                     <template x-for="relatedArticle in related" :key="relatedArticle.id">
                         <div class="related-card fade-in">
-                            <h5><a :href="relatedArticle.url" x-text="relatedArticle.title"></a></h5>
+                            <h5><a :href="relatedArticle.href" x-text="relatedArticle.title"></a></h5>
                             <p x-text="relatedArticle.excerpt"></p>
                         </div>
                     </template>

--- a/dist/data/footer.json
+++ b/dist/data/footer.json
@@ -3,18 +3,9 @@
         "title": "Quick Links",
         "items": [
             {"name": "Home", "href": "index.html"},
-            {"name": "About", "href": "#about"},
-            {"name": "Services", "href": "#services"},
-            {"name": "Contact", "href": "#contact"}
-        ]
-    },
-    {
-        "title": "Services",
-        "items": [
-            {"name": "Web Development", "href": "#"},
-            {"name": "Design", "href": "#"},
-            {"name": "Consulting", "href": "#"},
-            {"name": "Support", "href": "#"}
+            {"name": "Get Started", "href": "GetStarted.html"},
+            {"name": "Manifesto", "href": "RelationalDesignManifesto.html"},
+            {"name": "About", "href": "index.html#about"}
         ]
     },
     {

--- a/dist/data/menu.json
+++ b/dist/data/menu.json
@@ -1,8 +1,6 @@
 [
     { "name": "Home", "href": "index.html", "active": true },
-    { "name": "About", "href": "about.html", "active": false },
-    { "name": "Articles", "href": "articles.html", "active": false },
+    { "name": "Get Started", "href": "GetStarted.html", "active": false },
     { "name": "Manifesto", "href": "RelationalDesignManifesto.html", "active": false },
-    { "name": "Blog", "href": "blog.html", "active": false },
-    { "name": "Contact", "href": "contact.html", "active": false }
+    { "name": "About", "href": "index.html#about", "active": false }
 ]

--- a/dist/index.html
+++ b/dist/index.html
@@ -173,7 +173,7 @@
                 <p>
                     Be the first to get access to our whitepaper, case studies, and community.
                 </p>
-                <button onclick="location.href='/invite-request'"
+                <button onclick="location.href='GetStarted.html'"
                     onmouseover="this.innerText='It starts with a conversation.'"
                     onmouseout="this.innerText='Request an Invitation';">
                     Request an Invitation


### PR DESCRIPTION
## Summary
- prune menu.json to only link to existing pages and add "Get Started"
- simplify footer links to match current site sections
- fix Related Articles links on GetStarted page
- point homepage invitation button at existing page

## Testing
- `htmlhint "dist/*.html"`
- `curl -I http://localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_688e53362dc8832788f66bb21fcf510d