### PR TITLE
Add tags metadata to articles

### DIFF
--- a/dist/GetStarted.html
+++ b/dist/GetStarted.html
@@ -25,6 +25,7 @@
                 },
                 publishDate: '2025-07-28',
                 readTime: '9 min read',
+                tags: ['relational design', 'guide', 'co-creation'],
                 currentPage: 1,
                 totalPages: 1
             },

--- a/dist/RelationalDesignManifesto.html
+++ b/dist/RelationalDesignManifesto.html
@@ -23,6 +23,7 @@
                 },
                 publishDate: '2025-08-01',    // YYYY-MM-DD
                 readTime: '7 min read',       // e.g. '5 min read'
+                tags: ['manifesto', 'philosophy', 'relational design'],
                 currentPage: 1,
                 totalPages: 1
             },

--- a/templates/article-template.html
+++ b/templates/article-template.html
@@ -23,6 +23,7 @@
                 },
                 publishDate: '',    // YYYY-MM-DD
                 readTime: '',       // e.g. '5 min read'
+                tags: [],           // e.g. ['seo', 'cms', 'automation']
                 currentPage: 1,
                 totalPages: 1
             },


### PR DESCRIPTION
## Summary
- include `tags` array in `window.articleData.article` template to support article keywords
- provide descriptive tags in existing article metadata

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e70a9a1848327b24a67c02240b5f9