### PR TITLE
chore: add site build workflow

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -1,0 +1,26 @@
+name: Build site
+
+on:
+  push:
+    paths:
+      - 'dist/**/*.html'
+      - 'dist/**/*.md'
+      - 'content/**/*.html'
+      - 'content/**/*.md'
+  pull_request:
+    paths:
+      - 'dist/**/*.html'
+      - 'dist/**/*.md'
+      - 'content/**/*.html'
+      - 'content/**/*.md'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run build:site

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ The `templates/` directory contains stripped-down HTML examples that can be copi
 
 Copy the desired file, rename it and replace the placeholder comments with your content. The templates already include the dynamic navigation and footer logic so only the page-specific sections need to be filled in.
 
+## Automated builds
+
+Run `npm run build:site` to regenerate navigation lists and related links after adding or editing articles. A GitHub Actions workflow automatically runs this command whenever Markdown or HTML files change in `content/` or `dist/`, keeping generated lists up to date.
+
 ## Notes
 
 - How to set up multiple identities for GitHub

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "relationaldesign",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "relationaldesign",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "relationaldesign",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build:site": "node scripts/build.js"
+  }
+}


### PR DESCRIPTION
## Summary
- add package.json with build:site script
- run site build in CI when HTML/Markdown in content or dist changes
- document build automation

## Testing
- `npm run build:site`


------
https://chatgpt.com/codex/tasks/task_e_688e75ac5614832797169ef6abe691c1